### PR TITLE
Restore main stylesheet for portfolio site

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,1001 @@
+:root {
+    --color-primary: #122f57;
+    --color-secondary: #1c4e80;
+    --color-accent: #4a78b0;
+    --color-text: #13223a;
+    --color-text-muted: #5b6b83;
+    --color-bg: #f5f7fa;
+    --color-surface: #ffffff;
+    --color-surface-muted: #eef2f8;
+    --shadow-soft: 0 18px 48px rgba(18, 47, 87, 0.08);
+    --shadow-card: 0 20px 60px rgba(18, 47, 87, 0.12);
+    --radius-small: 10px;
+    --radius-medium: 16px;
+    --radius-large: 24px;
+    --font-display: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --font-text: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --transition: all 200ms ease;
+    --max-width: 1180px;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    font-size: 16px;
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-text);
+    background: linear-gradient(180deg, #f9fbff 0%, var(--color-bg) 60%, #e8f0ff 100%);
+    color: var(--color-text);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+
+img,
+svg {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    text-decoration: none;
+}
+
+p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    color: var(--color-text-muted);
+}
+
+strong {
+    color: var(--color-text);
+}
+
+section {
+    padding: 96px 0;
+}
+
+.container {
+    width: min(100%, var(--max-width));
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+main {
+    display: block;
+}
+
+/* Navigation */
+
+.nav {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: rgba(245, 247, 250, 0.92);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(18, 47, 87, 0.06);
+}
+
+.nav-container {
+    width: min(100%, var(--max-width));
+    margin: 0 auto;
+    padding: 20px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 32px;
+}
+
+.nav-logo {
+    font-family: var(--font-display);
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--color-primary);
+}
+
+.nav-menu {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+}
+
+.nav-link {
+    font-weight: 500;
+    font-size: 0.95rem;
+    color: var(--color-text-muted);
+    position: relative;
+    padding-bottom: 6px;
+    transition: var(--transition);
+}
+
+.nav-link::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg, var(--color-primary), var(--color-accent));
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: var(--transition);
+}
+
+.nav-link:hover,
+.nav-link:focus,
+.nav-link.active {
+    color: var(--color-primary);
+}
+
+.nav-link:hover::after,
+.nav-link:focus::after,
+.nav-link.active::after {
+    transform: scaleX(1);
+}
+
+.nav-toggle {
+    display: none;
+    width: 36px;
+    height: 28px;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.nav-toggle span {
+    display: block;
+    height: 3px;
+    border-radius: 999px;
+    background: var(--color-primary);
+}
+
+/* Hero */
+
+.hero {
+    padding-top: 120px;
+    background: radial-gradient(circle at top right, rgba(74, 120, 176, 0.18), transparent 50%),
+        radial-gradient(circle at bottom left, rgba(18, 47, 87, 0.18), transparent 50%);
+}
+
+.research-hero {
+    padding-top: 140px;
+    background: linear-gradient(160deg, rgba(18, 47, 87, 0.08), rgba(74, 120, 176, 0.12));
+}
+
+.research-hero .hero-text > p:first-child {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(18, 47, 87, 0.08);
+    color: var(--color-secondary);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    margin-bottom: 18px;
+}
+
+.research-hero .hero-title {
+    font-size: clamp(2.5rem, 4vw, 3.25rem);
+}
+
+.hero-container {
+    width: min(100%, var(--max-width));
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+.hero-content {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 64px;
+    align-items: center;
+}
+
+.hero-title {
+    font-family: var(--font-display);
+    font-size: clamp(2.75rem, 3.8vw, 3.75rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--color-primary);
+    margin-bottom: 24px;
+}
+
+.hero-accent {
+    display: inline-block;
+    color: var(--color-accent);
+}
+
+.hero-subtitle {
+    font-size: 1.125rem;
+    line-height: 1.8;
+    color: var(--color-text-muted);
+    margin-bottom: 32px;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.hero-visual {
+    display: flex;
+    justify-content: center;
+}
+
+.hero-card {
+    width: min(100%, 380px);
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    box-shadow: var(--shadow-card);
+    padding: 32px;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.card-dots span {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    margin-right: 6px;
+    border-radius: 50%;
+    background: rgba(74, 120, 176, 0.35);
+}
+
+.card-dots span:first-child {
+    background: #ff6b6b;
+}
+
+.card-dots span:nth-child(2) {
+    background: #f7b955;
+}
+
+.card-title {
+    font-weight: 600;
+    color: var(--color-text-muted);
+}
+
+.metric {
+    margin-bottom: 16px;
+}
+
+.metric-value {
+    display: block;
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    letter-spacing: -0.02em;
+}
+
+.metric-label {
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+}
+
+.chart {
+    width: 100%;
+    height: auto;
+}
+
+/* Sections */
+
+.section-header {
+    margin-bottom: 40px;
+}
+
+.section-title {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 3vw, 2.75rem);
+    margin: 0 0 8px;
+    color: var(--color-primary);
+}
+
+.section-subtitle {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.section {
+    padding: 96px 0;
+}
+
+/* About */
+
+.about {
+    background: var(--color-surface);
+}
+
+.about-content {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    gap: 48px;
+}
+
+.about-intro {
+    font-size: 1.1rem;
+    color: var(--color-text);
+}
+
+.values-grid {
+    margin-top: 32px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+}
+
+.value-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 18px;
+    border-radius: var(--radius-medium);
+    background: var(--color-surface-muted);
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.value-icon {
+    font-size: 1.4rem;
+}
+
+.personal-card {
+    background: linear-gradient(160deg, rgba(18, 47, 87, 0.92), rgba(74, 120, 176, 0.88));
+    color: white;
+    padding: 32px;
+    border-radius: var(--radius-large);
+    box-shadow: var(--shadow-card);
+}
+
+.personal-header {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.personal-avatar {
+    width: 68px;
+    height: 68px;
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.15);
+    display: grid;
+    place-items: center;
+}
+
+.avatar-placeholder {
+    font-weight: 700;
+    font-size: 1.5rem;
+    letter-spacing: 0.08em;
+}
+
+.personal-info h3 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.personal-info p {
+    margin: 4px 0;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.personal-details {
+    display: grid;
+    gap: 16px;
+}
+
+.detail-item {
+    display: flex;
+    flex-direction: column;
+}
+
+.detail-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.detail-value {
+    font-weight: 600;
+}
+
+/* Career */
+
+.career {
+    background: var(--color-bg);
+}
+
+.role-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 32px;
+    box-shadow: var(--shadow-soft);
+}
+
+.role-header {
+    display: flex;
+    gap: 24px;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.company-logo {
+    width: 56px;
+    height: 56px;
+    border-radius: 18px;
+    background: var(--color-secondary);
+    color: white;
+    font-weight: 700;
+    display: grid;
+    place-items: center;
+    font-size: 1.5rem;
+}
+
+.role-info h3 {
+    margin: 0 0 6px;
+    font-size: 1.4rem;
+}
+
+.role-info p {
+    margin: 0;
+    color: var(--color-text-muted);
+}
+
+.role-type {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(18, 47, 87, 0.08);
+    color: var(--color-primary);
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.role-summary {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.skills-section {
+    margin-top: 48px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+}
+
+.skills-category h4 {
+    margin-bottom: 16px;
+    color: var(--color-primary);
+}
+
+.skills-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.skill-tag {
+    padding: 8px 14px;
+    background: var(--color-surface-muted);
+    color: var(--color-primary);
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.achievements {
+    margin-top: 48px;
+}
+
+.achievement-list {
+    display: grid;
+    gap: 16px;
+}
+
+.achievement-item {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+    padding: 20px;
+    border-radius: var(--radius-medium);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-soft);
+}
+
+.achievement-icon {
+    font-size: 1.8rem;
+    line-height: 1;
+}
+
+/* Projects & Research */
+
+.projects,
+.research {
+    background: var(--color-surface);
+}
+
+.projects-grid,
+.interests-grid,
+.projects .projects-grid,
+.section .projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
+}
+
+.project-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 28px;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.project-card:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--shadow-card);
+}
+
+.project-card h3 {
+    margin: 0;
+    color: var(--color-primary);
+}
+
+.project-card p {
+    margin: 0;
+}
+
+.project-card.featured {
+    background: linear-gradient(160deg, rgba(18, 47, 87, 0.96), rgba(74, 120, 176, 0.9));
+    color: white;
+    box-shadow: var(--shadow-card);
+}
+
+.project-card.featured p,
+.project-card.featured span {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.project-status {
+    align-self: flex-start;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(74, 120, 176, 0.12);
+    color: var(--color-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.project-status.planning {
+    background: rgba(247, 185, 85, 0.2);
+    color: #b8761d;
+}
+
+.project-status.prototype {
+    background: rgba(82, 196, 26, 0.18);
+    color: #2f8f22;
+}
+
+.project-status.exploration {
+    background: rgba(255, 107, 107, 0.18);
+    color: #d64545;
+}
+
+.project-impact {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 0.95rem;
+}
+
+.impact-label {
+    font-weight: 600;
+    color: inherit;
+}
+
+.project-stack,
+.project-note {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    font-size: 0.9rem;
+}
+
+.stack-tag {
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(18, 47, 87, 0.08);
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.projects .btn,
+.section .btn {
+    align-self: flex-start;
+}
+
+/* Research article sections */
+
+.section ul,
+.section ol {
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    margin: 0 0 24px 0;
+    padding-left: 24px;
+    display: grid;
+    gap: 12px;
+}
+
+.section ul li,
+.section ol li {
+    padding-left: 4px;
+}
+
+.section ul li strong {
+    color: var(--color-primary);
+}
+
+.best-practices ol {
+    counter-reset: item;
+}
+
+.best-practices ol > li {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 24px;
+    box-shadow: var(--shadow-soft);
+}
+
+.best-practices h3 {
+    margin-top: 0;
+    color: var(--color-primary);
+}
+
+.executive-summary ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+.executive-summary li {
+    position: relative;
+    padding-left: 28px;
+}
+
+.executive-summary li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 12px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+}
+
+/* Interests */
+
+.interests {
+    background: var(--color-bg);
+}
+
+.interests-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.interest-card {
+    background: var(--color-surface);
+    padding: 24px;
+    border-radius: var(--radius-large);
+    box-shadow: var(--shadow-soft);
+    text-align: center;
+    transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.interest-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-card);
+}
+
+.interest-icon {
+    font-size: 2rem;
+    margin-bottom: 12px;
+}
+
+/* Contact */
+
+.contact {
+    background: linear-gradient(160deg, rgba(18, 47, 87, 0.1), rgba(74, 120, 176, 0.08));
+}
+
+.contact-content {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 48px;
+}
+
+.contact-card,
+.speaking-topics {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 28px;
+    box-shadow: var(--shadow-soft);
+}
+
+.opportunity-list,
+.topics-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.contact-form {
+    background: var(--color-surface);
+    padding: 32px;
+    border-radius: var(--radius-large);
+    box-shadow: var(--shadow-card);
+    display: grid;
+    gap: 20px;
+}
+
+.form-group {
+    display: grid;
+    gap: 8px;
+}
+
+label {
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+input,
+textarea {
+    width: 100%;
+    padding: 12px 16px;
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(18, 47, 87, 0.12);
+    font-family: inherit;
+    font-size: 1rem;
+    background: var(--color-surface-muted);
+    transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+input:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px rgba(74, 120, 176, 0.18);
+}
+
+textarea {
+    resize: vertical;
+}
+
+.social-links {
+    margin-top: 48px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 18px;
+}
+
+.social-link {
+    width: 46px;
+    height: 46px;
+    border-radius: 16px;
+    display: grid;
+    place-items: center;
+    background: var(--color-surface);
+    color: var(--color-primary);
+    box-shadow: var(--shadow-soft);
+    transition: var(--transition);
+}
+
+.social-link:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-card);
+    color: var(--color-accent);
+}
+
+/* Buttons */
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 22px;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    font-size: 0.95rem;
+    cursor: pointer;
+    border: none;
+    transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+    color: white;
+    box-shadow: var(--shadow-soft);
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-card);
+}
+
+.btn-secondary {
+    background: rgba(18, 47, 87, 0.08);
+    color: var(--color-primary);
+}
+
+.btn-secondary:hover {
+    transform: translateY(-2px);
+    background: rgba(18, 47, 87, 0.14);
+}
+
+/* Footer */
+
+.footer {
+    background: #0f1d33;
+    color: rgba(255, 255, 255, 0.76);
+    padding: 40px 0;
+}
+
+.footer-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.footer p {
+    margin: 0;
+    color: inherit;
+}
+
+/* Utility */
+
+.card {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 24px;
+    box-shadow: var(--shadow-soft);
+}
+
+blockquote {
+    margin: 16px 0;
+    padding: 16px 20px;
+    border-left: 4px solid var(--color-accent);
+    background: rgba(74, 120, 176, 0.08);
+    border-radius: var(--radius-medium);
+    color: var(--color-text);
+}
+
+main,
+section,
+.nav {
+    width: 100%;
+}
+
+/* Responsive */
+
+@media (max-width: 1024px) {
+    .hero-content {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .hero-actions {
+        justify-content: center;
+    }
+
+    .hero-visual {
+        order: -1;
+    }
+
+    .about-content,
+    .contact-content {
+        grid-template-columns: 1fr;
+    }
+
+    .personal-card {
+        margin-inline: auto;
+    }
+
+    .nav-menu {
+        display: none;
+    }
+
+    .nav-toggle {
+        display: flex;
+    }
+}
+
+@media (max-width: 768px) {
+    section,
+    .section {
+        padding: 72px 0;
+    }
+
+    .nav-container {
+        padding: 16px 20px;
+    }
+
+    .hero {
+        padding-top: 100px;
+    }
+
+    .projects-grid,
+    .interests-grid,
+    .section .projects-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .project-card {
+        padding: 24px;
+    }
+
+    .contact-form {
+        padding: 24px;
+    }
+
+    .social-links {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 540px) {
+    html {
+        font-size: 15px;
+    }
+
+    .values-grid {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+
+    .hero-card {
+        padding: 24px;
+    }
+
+    .section-title {
+        font-size: 2.25rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
## Summary
- recreate the missing `css/main.css` stylesheet with Apple-inspired typography, color variables, layout, and responsive rules to match the portfolio design
- cover navigation, hero, about, career, projects, research, interests, and contact sections plus shared utilities for cards, buttons, and article styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb05003548832ab2e5c490fa05bea9